### PR TITLE
Remove CACHE CGT Token

### DIFF
--- a/src/tokens/allTokens.json
+++ b/src/tokens/allTokens.json
@@ -25883,20 +25883,6 @@
   },
   {
     "chainId": 137,
-    "name": "CACHE Gold",
-    "symbol": "CGT",
-    "decimals": 8,
-    "address": "0xc17d249c8a675c2e67a5b305a3e6b23cc45d81aa",
-    "tags": [
-      "pos",
-      "erc20"
-    ],
-    "extensions": {
-      "rootAddress": "0xf5238462e7235c7b62811567e63dd17d12c2eaa0"
-    }
-  },
-  {
-    "chainId": 137,
     "name": "Yield",
     "symbol": "YLD",
     "decimals": 18,


### PR DESCRIPTION
Remove token with the following details to resolve #204 

Token Name: CACHE Gold Token
Token Symbol: CGT
Decimals: 8
Polygon Address: 0xc17D249C8A675C2e67A5B305A3e6b23cC45d81Aa Ethereum Address: 0xF5238462E7235c7B62811567E63Dd17d12C2EAA0 Logo URI (svg):
Project Name:
Project Summary: 
Project Contact: Dias Lonappan / Brian Hankey dias@cache.gold / brian@cache.gold Project Website: cache.gold

Additional Notes: This mapping was created very early on without consideration for the certain token features. This mapping is incorrect, because we have another bridge. The Polygon Bridge will not work and will result in a loss of user funds.