### PR TITLE
Add bIB01: Backed IB01 $ Treasury Bond 0-1yr

### DIFF
--- a/src/tokens/polygonTokens.json
+++ b/src/tokens/polygonTokens.json
@@ -20673,5 +20673,23 @@
                 "website": "https://noggles.com"
             }
         }
+    },
+    {
+        "chainId": 137,
+        "name": "Backed IB01 $ Treasury Bond 0-1yr",
+        "symbol": "bIB01",
+        "decimals": 18,
+        "address": "0xca30c93b02514f86d5c86a6e375e3a330b435fb5",
+        "logoURI": "https://svgshare.com/i/wi7.svg",
+        "tags": ["pos", "erc20"],
+        "extensions": {
+            "rootAddress": "0xca30c93b02514f86d5c86a6e375e3a330b435fb5",
+            "project": {
+                "name": "Backed Finance",
+                "summary": "Backed Finance, via its issuer, Backed Assets, is issuing tokens that track real-world assets, fully backed by the underlying assets. bIB01 is a tracker of IB01, an accumulating 0-1y T-Bills ETF, issued by iShares in Ireland.",
+                "contact": "contact@backed.fi",
+                "website": "https://backed.fi"
+            }
+        }
     }
 ]


### PR DESCRIPTION
-   [x] I understand that token listing is not required to use the Polygon Wallet with a token.

**Please provide the following information for your token.**

Token Name: Backed IB01 $ Treasury Bond 0-1yr
Token Symbol: bIB01
Decimals: 18
Polygon Address: 0xca30c93b02514f86d5c86a6e375e3a330b435fb5
Ethereum Address: 0xca30c93b02514f86d5c86a6e375e3a330b435fb5
Logo URI (svg): https://svgshare.com/i/wi7.svg
Project Name: Backed Finance
Project Summary: Backed Finance, via its issuer, Backed Assets, is issuing tokens that track real-world assets, fully backed by the underlying assets. bIB01 is a tracker of IB01, an accumulating 0-1y T-Bills ETF, issued by iShares in Ireland.
Project Contact: contact@backed.fi
Project Website: [backed.fi](backed.fi)

Mainnet/Testnet: Mainnet
Additonal Notes:
