### PR TITLE
chore: remove maha from popularTokens

### DIFF
--- a/src/tokens/popularTokens.json
+++ b/src/tokens/popularTokens.json
@@ -793,18 +793,6 @@
     },
     {
         "chainId": 137,
-        "name": "MahaDAO",
-        "symbol": "MAHA",
-        "decimals": 18,
-        "address": "0xeDd6cA8A4202d4a36611e2fff109648c4863ae19",
-        "tags": ["pos", "erc20", "swapable"],
-        "extensions": {
-            "rootAddress": "0xb4d930279552397bba2ee473229f89ec245bc365"
-        },
-        "logoURI": "https://assets.polygon.technology/tokenAssets/maha.svg"
-    },
-    {
-        "chainId": 137,
         "name": "PoolTogether",
         "symbol": "POOL",
         "decimals": 18,


### PR DESCRIPTION
**Changes**

- remove Maha from popularTokens

```
    {
        "chainId": 137,
        "name": "MahaDAO",
        "symbol": "MAHA",
        "decimals": 18,
        "address": "0xeDd6cA8A4202d4a36611e2fff109648c4863ae19",
        "tags": ["pos", "erc20", "swapable"],
        "extensions": {
            "rootAddress": "0xb4d930279552397bba2ee473229f89ec245bc365"
        },
        "logoURI": "https://assets.polygon.technology/tokenAssets/maha.svg"
    },
```