### PR TITLE
Feat/legacy

### DIFF
--- a/src/metadata/polygon.json
+++ b/src/metadata/polygon.json
@@ -59,6 +59,10 @@
         "customZkevmBridge": {
             "name": "Custom Zkevm Bridge",
             "description": "Tokens that are bridged using zkEVM messaging layer"
+        },
+        "legacy": {
+            "name": "Legacy Token",
+            "description": "Tokens that are legacy"
         }
     }
 }

--- a/src/metadata/polygonPopular.json
+++ b/src/metadata/polygonPopular.json
@@ -59,6 +59,10 @@
         "customZkevmBridge": {
             "name": "Custom Zkevm Bridge",
             "description": "Tokens that are bridged using zkEVM messaging layer"
+        },
+        "legacy": {
+            "name": "Legacy Token",
+            "description": "Tokens that are legacy"
         }
     }
 }

--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -22404,7 +22404,7 @@
         "decimals": 6,
         "address": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
         "logoURI": "https://assets.polygon.technology/tokenAssets/usdc.svg",
-        "tags": ["lxly", "stablecoin", "erc20"],
+        "tags": ["lxly", "stablecoin", "erc20", "legacy"],
         "extensions": {
             "originTokenAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "originTokenNetwork": 0,
@@ -22448,7 +22448,7 @@
         "decimals": 18,
         "address": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
         "logoURI": "https://assets.polygon.technology/tokenAssets/dai.svg",
-        "tags": ["lxly", "stablecoin", "erc20"],
+        "tags": ["lxly", "stablecoin", "erc20", "legacy"],
         "extensions": {
             "originTokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "originTokenNetwork": 0,

--- a/src/tokens/polygonPopular.json
+++ b/src/tokens/polygonPopular.json
@@ -1346,7 +1346,7 @@
         "decimals": 6,
         "address": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
         "logoURI": "https://assets.polygon.technology/tokenAssets/usdc.svg",
-        "tags": ["lxly", "stablecoin", "erc20"],
+        "tags": ["lxly", "stablecoin", "erc20", "legacy"],
         "extensions": {
             "originTokenAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
             "originTokenNetwork": 0,
@@ -1390,7 +1390,7 @@
         "decimals": 18,
         "address": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
         "logoURI": "https://assets.polygon.technology/tokenAssets/dai.svg",
-        "tags": ["lxly", "stablecoin", "erc20"],
+        "tags": ["lxly", "stablecoin", "erc20", "legacy"],
         "extensions": {
             "originTokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
             "originTokenNetwork": 0,


### PR DESCRIPTION
**Changes**
- Add legacy tag
DAI - DAI.e will have the legacy tag, so this should only be shown for L2-L1. For L1-L2 we should use the new DAI using custom bridge
USDC - Old USDC will have legacy tag, so this should only be shown for L2-L1. For L1-L2 we should use the USDC.e where L1->L2 we show it as USDC and L2->L1 (we show it as USDC.e)