### PR TITLE
Add PowerMaxCoin erc20 token

### DIFF
--- a/src/tokens/polygonTokens.json
+++ b/src/tokens/polygonTokens.json
@@ -20771,5 +20771,14 @@
                 "website": ""
             }
         }
+    },
+    {
+        "chainId": 137,
+        "name": "PowerMaxCoin",
+        "symbol": "PMX",
+        "decimals": 18,
+        "address": "0x92ff3278dd506622da85a6dca6e6505ee428ccbc",
+        "logoURI": "https://raw.githubusercontent.com/pmx369/assets/main/logo.png",
+        "tags": ["erc20", "fx"]
     }
 ]


### PR DESCRIPTION

[ x ] I understand that token listing is not required to use the Polygon Wallet with a token.
Please provide the following information for your token.

Token Name: PowerMaxCoin
Token Symbol: PMX
Decimals: 18
Polygon Address: 0x92FF3278dd506622dA85a6Dca6e6505EE428cCbc
Logo URI: https://raw.githubusercontent.com/pmx369/assets/main/logo.png

Mainnet/Testnet: Mainnet