### PR TITLE
feat: Add Risy DAO (RISY) token to Polygon token list

### DIFF
--- a/src/tokens/polygonTokens.json
+++ b/src/tokens/polygonTokens.json
@@ -20846,6 +20846,29 @@
         }
     },
     {
+        "chainId": 137,
+        "name": "Risy DAO",
+        "symbol": "RISY",
+        "decimals": 18,
+        "address": "0xca154cF88F6ffBC23E16B5D08a9Bf4851FB97199",
+        "logoURI": "https://raw.githubusercontent.com/RisyDAO/contract-metadata/1351b3465ab8f71d5a7e9def0c4d674a8f0d8382/images/RISY.svg",
+        "tags": [
+            "erc20",
+            "noDeposit",
+            "noWithdraw",
+            "swapable"
+        ],
+        "extensions": {
+            "originTokenNetwork": -1,
+            "project": {
+                "name": "Risy DAO",
+                "summary": "Risy DAO is revolutionizing DeFi with innovative tokenomics, community governance, and sustainable growth mechanisms on the Polygon blockchain.",
+                "contact": "info@risy.io",
+                "website": "https://risy.io"
+            }
+        }
+    },
+    {
       "chainId": 137,
       "name": "Tetu bridge token",
       "symbol": "fxTETU",


### PR DESCRIPTION
## Description
Adding Risy DAO (RISY) token to the Polygon token list. RISY is a Polygon-based token with innovative tokenomics and community governance features.

## Token Information
- Name: Risy DAO
- Symbol: RISY
- Contract: 0xca154cF88F6ffBC23E16B5D08a9Bf4851FB97199
- Decimals: 18
- Chain: Polygon PoS
- Website: https://risy.io

## Features
- Polygon-based token (not bridged)
- Available on QuickSwap DEX
- Community governance through DAO
- Daily transfer limit mechanism for price stability
- 0.1% DAO fee on transfers

## Verification Links
- Contract: https://polygonscan.com/token/0xca154cF88F6ffBC23E16B5D08a9Bf4851FB97199
- Logo: https://raw.githubusercontent.com/RisyDAO/contract-metadata/1351b3465ab8f71d5a7e9def0c4d674a8f0d8382/images/RISY.svg
- Documentation: https://risy.io

## Checklist
- [x] Token contract is verified on Polygonscan
- [x] Logo is hosted on a permanent URL (commit-specific)
- [x] Token information is accurate and complete
- [x] Added appropriate tags (erc20, swapable, noDeposit, noWithdraw)
- [x] Followed the JSON schema format
- [x] Ran linter and tests successfully