### PR TITLE
Add Gigachad E.G.A. (GEGA) token to Polygon token list

### DIFF
--- a/src/tokens/137.json
+++ b/src/tokens/137.json
@@ -1,0 +1,10 @@
+[
+  {
+    "chainId": 137,
+    "address": "0x357a9EDDd2A784FC1a610A81cC40531eD3f89705",
+    "name": "Gigachad E.G.A.",
+    "symbol": "GEGA",
+    "decimals": 18,
+    "logoURI": "https://bafybeiejawfrlsvdzjo7w7qt5eq4x7w3jpnntd3gvjp7epzj7uuqvvktmu.ipfs.w3s.link/GEGA.png"
+  }
+]


### PR DESCRIPTION
This PR adds the Gigachad E.G.A. (GEGA) token to the Polygon token list.
- Chain ID: 137
- Contract Address: 0x357a9EDDd2A784FC1a610A81cC40531eD3f89705
- Metadata URL: https://bafybeidwcoxl5exfh4chgbx72zbj6hpuulqcbucsu7fkhoi5cog6wjadxi.ipfs.w3s.link