### PR TITLE
fix: correct WBTC and vbWBTC decimals to 8 on X Layer and Ternoa

### DIFF
--- a/src/tokens/agglayer.json
+++ b/src/tokens/agglayer.json
@@ -857,7 +857,7 @@
         "address": "0xea034fb02eb1808c2cc3adbc15f447b93cbe08e1",
         "name": "Wrapped BTC",
         "symbol": "WBTC",
-        "decimals": 18,
+        "decimals": 8,
         "tags": [
             "wrapped"
         ],
@@ -876,7 +876,7 @@
         "address": "0x593A86cB824e0e3546fAE6bbC56e6f3f3EB6213E",
         "name": "Vault Bridge WBTC",
         "symbol": "vbWBTC",
-        "decimals": 18,
+        "decimals": 8,
         "tags": [
             "wrapped"
         ],


### PR DESCRIPTION
## What

Corrects the `decimals` field on two agglayer token-list entries from `18` to `8`:

- **X Layer (196)** WBTC `0xea034fb02eb1808c2cc3adbc15f447b93cbe08e1`
- **Ternoa (752025)** vbWBTC `0x593A86cB824e0e3546fAE6bbC56e6f3f3EB6213E`

#