### PR TITLE
chore: remove Polygon zkEVM (network sunset) from all tokenlists

### DIFF
--- a/src/metadata/agglayer.json
+++ b/src/metadata/agglayer.json
@@ -112,29 +112,6 @@
             "active": true
         },
         {
-            "chainId": 1101,
-            "blockExplorerUrl": "https://www.oklink.com/polygon-zkevm",
-            "chainType": "EVM",
-            "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/zkevm.svg",
-            "name": "Polygon zkEVM",
-            "nativeCurrency": {
-                "decimals": 18,
-                "name": "Ether",
-                "symbol": "ETH",
-                "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/ethereum.svg"
-            },
-            "rpcURL": "https://zkevm-rpc.com",
-            "supportedRoutes": [
-                "lifi",
-                "agglayer"
-            ],
-            "networkId": 1,
-            "autoClaimEnabled": true,
-            "lxlyVersion": 1,
-            "verifiedBatchSubmissionPeriod": 10800,
-            "active": true
-        },
-        {
             "chainId": 747474,
             "blockExplorerUrl": "https://katanascan.com",
             "chainType": "EVM",

--- a/src/tokens/agglayer.json
+++ b/src/tokens/agglayer.json
@@ -91,23 +91,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0x0000000000000000000000000000000000000000",
-        "name": "Ether",
-        "symbol": "ETH",
-        "decimals": 18,
-        "tags": [
-            "governanceToken"
-        ],
-        "logoURI": "https://assets.polygon.technology/tokenAssets/eth.svg",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x0000000000000000000000000000000000000000",
-            "supportedRoutes": [
-                "lifi"
-            ]
-        }
-    },
-    {
         "chainId": 747474,
         "address": "0x0000000000000000000000000000000000000000",
         "name": "Ether",
@@ -245,23 +228,6 @@
             "canonical"
         ],
         "logoURI": "https://assets.polygon.technology/tokenAssets/usdc.svg",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            "supportedRoutes": [
-                "lifi"
-            ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0xA8CE8aee21bC2A48a5EF670afCc9274C7bbbC035",
-        "name": "USD Coin",
-        "symbol": "USDC",
-        "decimals": 6,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
         "extensions": {
             "originAssetId": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             "supportedRoutes": [
@@ -457,23 +423,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0x1E4a5963aBFD975d8c9021ce480b42188849D41d",
-        "name": "Tether USD",
-        "symbol": "USDT",
-        "decimals": 6,
-        "tags": [
-            "canonical"
-        ],
-        "logoURI": "https://assets.polygon.technology/tokenAssets/usdt.svg",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
-            "supportedRoutes": [
-                "lifi"
-            ]
-        }
-    },
-    {
         "chainId": 747474,
         "address": "0x2DCa96907fde857dd3D816880A0df407eeB2D2F2",
         "name": "Vault Bridge USDT",
@@ -623,23 +572,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0x4F9A0e7FD2Bf6067db6994CF12E4495Df938E6e9",
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
-        "decimals": 18,
-        "tags": [
-            "canonical"
-        ],
-        "logoURI": "https://static.debank.com/image/pze_token/logo_url/0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9/61844453e63cf81301f845d7864236f6.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-            "supportedRoutes": [
-                "lifi"
-            ]
-        }
-    },
-    {
         "chainId": 8453,
         "address": "0x4200000000000000000000000000000000000006",
         "name": "Wrapped Ether",
@@ -734,23 +666,6 @@
     {
         "chainId": 137,
         "address": "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
-        "name": "Wrapped BTC",
-        "symbol": "WBTC",
-        "decimals": 8,
-        "tags": [
-            "canonical"
-        ],
-        "logoURI": "https://assets.polygon.technology/tokenAssets/wbtc.svg",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-            "supportedRoutes": [
-                "lifi"
-            ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0xEA034fb02eB1808C2cc3adbC15f447B93CbE08e1",
         "name": "Wrapped BTC",
         "symbol": "WBTC",
         "decimals": 8,
@@ -1132,25 +1047,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
-        "name": "DAI Stablecoin",
-        "symbol": "DAI",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            "originTokenNetwork": 0
-        }
-    },
-    {
         "chainId": 747474,
         "address": "0x2ff27ca276ff52a4e7c40ff87983c45a4a049e5e",
         "name": "DAI Stablecoin",
@@ -1246,25 +1142,6 @@
     },
     {
         "chainId": 196,
-        "address": "0x22b21beddef74fe62f031d2c5c8f7a9f8a4b304d",
-        "name": "Polygon Ecosystem Token",
-        "symbol": "POL",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://assets.polygon.technology/tokenAssets/matic.svg",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
-            "originTokenNetwork": 0
-        }
-    },
-    {
-        "chainId": 1101,
         "address": "0x22b21beddef74fe62f031d2c5c8f7a9f8a4b304d",
         "name": "Polygon Ecosystem Token",
         "symbol": "POL",
@@ -1410,25 +1287,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0x4b16e4752711a7abec32799c976f3cefc0111f2b",
-        "name": "ChainLink Token",
-        "symbol": "LINK",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/matic_token/logo_url/0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39/69425617db0ef93a7c21c4f9b81c7ca5.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
-            "originTokenNetwork": 0
-        }
-    },
-    {
         "chainId": 1,
         "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
         "name": "Uniswap",
@@ -1515,25 +1373,6 @@
             "supportedRoutes": [
                 "lifi"
             ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0x2548c94a3092494db3af864cc2cf781a72f55678",
-        "name": "Uniswap",
-        "symbol": "UNI",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/arb_token/logo_url/0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0/fcee0c46fc9864f48ce6a40ed1cdd135.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-            "originTokenNetwork": 0
         }
     },
     {
@@ -1664,25 +1503,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0x68791cfe079814c46e0e25c19bcc5bfc71a744f7",
-        "name": "Aave Token",
-        "symbol": "AAVE",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://storage.googleapis.com/zapper-fi-assets/tokens/ethereum/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
-            "originTokenNetwork": 0
-        }
-    },
-    {
         "chainId": 752025,
         "address": "0x68791cfe079814c46e0e25c19bcc5bfc71a744f7",
         "name": "Aave Token",
@@ -1775,25 +1595,6 @@
     },
     {
         "chainId": 196,
-        "address": "0x3d5320821bfca19fb0b5428f2c79d63bd5246f89",
-        "name": "Curve DAO Token",
-        "symbol": "CRV",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://superfluid-finance.github.io/tokenlist/icons/crv.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xD533a949740bb3306d119CC777fa900bA034cd52",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0xD533a949740bb3306d119CC777fa900bA034cd52",
-            "originTokenNetwork": 0
-        }
-    },
-    {
-        "chainId": 1101,
         "address": "0x3d5320821bfca19fb0b5428f2c79d63bd5246f89",
         "name": "Curve DAO Token",
         "symbol": "CRV",
@@ -1917,25 +1718,6 @@
             "supportedRoutes": [
                 "lifi"
             ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0x120ef59b80774f02211563834d8e3b72cb1649d6",
-        "name": "Balancer",
-        "symbol": "BAL",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/arb_token/logo_url/0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8/52990c207f4001bd9090dfd90e54374a.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xba100000625a3754423978a60c9317c58a424e3D",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0xba100000625a3754423978a60c9317c58a424e3D",
-            "originTokenNetwork": 0
         }
     },
     {
@@ -2083,25 +1865,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0xc32cb86ae7921f45c0aa44f638d0ee8b67c98b98",
-        "name": "SushiToken",
-        "symbol": "SUSHI",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2/logo.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
-            "originTokenNetwork": 0
-        }
-    },
-    {
         "chainId": 1,
         "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
         "name": "Synthetix Network Token",
@@ -2188,25 +1951,6 @@
             "supportedRoutes": [
                 "lifi"
             ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0x90c6a9befa477ab3c3ec3b8be8dbc7a3e6ef1415",
-        "name": "Synthetix Network Token",
-        "symbol": "SNX",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/matic_token/logo_url/0x50b728d8d964fd00c2d0aad81718b71311fef68a/fb568c26c7902169572abe8fa966e791.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
-            "originTokenNetwork": 0
         }
     },
     {
@@ -2299,25 +2043,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0x2450e3153137c14ce4c113d63c427070e85bedec",
-        "name": "1INCH Token",
-        "symbol": "1INCH",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/matic_token/logo_url/0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f/73b05710c95a431e9e3c62dd5b8096ae.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x111111111117dC0aa78b770fA6A738034120C302",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x111111111117dC0aa78b770fA6A738034120C302",
-            "originTokenNetwork": 0
-        }
-    },
-    {
         "chainId": 1,
         "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
         "name": "Lido DAO Token",
@@ -2370,25 +2095,6 @@
             "supportedRoutes": [
                 "lifi"
             ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0x7e2feea957b7d1606335e339754f4e52b452b792",
-        "name": "Lido DAO Token",
-        "symbol": "LDO",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/arb_token/logo_url/0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60/3a1a90da5ccd4849de3e83755f1fd8b5.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
-            "originTokenNetwork": 0
         }
     },
     {
@@ -2519,25 +2225,6 @@
             "supportedRoutes": [
                 "lifi"
             ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0x70d35152fbf63fb312709b11a9bac87519de0019",
-        "name": "Rocket Pool",
-        "symbol": "RPL",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/arb_token/logo_url/0xb766039cc6db368759c1e56b79affe831d0cc507/f310ef0bdbf9f72e72cd54ff7f4d3ee6.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
-            "originTokenNetwork": 0
         }
     },
     {
@@ -2719,25 +2406,6 @@
         }
     },
     {
-        "chainId": 1101,
-        "address": "0xbb7835cefec0706829842927a645e64cf0a51bdf",
-        "name": "Graph Token",
-        "symbol": "GRT",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/arb_token/logo_url/0x9623063377ad1b27544c965ccd7342f7ea7e88c7/8a3fcf468cdf3ae0c7a56cfb12ab4816.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
-            "originTokenNetwork": 0
-        }
-    },
-    {
         "chainId": 1,
         "address": "0x75231F58b43240C9718Dd58B4967c5114342a86c",
         "name": "OKB",
@@ -2790,25 +2458,6 @@
             "supportedRoutes": [
                 "lifi"
             ]
-        }
-    },
-    {
-        "chainId": 1101,
-        "address": "0xa23390ab60fe5482e9230245eb817a8117528b38",
-        "name": "OKB",
-        "symbol": "OKB",
-        "decimals": 18,
-        "tags": [
-            "wrapped"
-        ],
-        "logoURI": "https://static.debank.com/image/xlayer_token/logo_url/0xe538905cf8410324e03a5a23c1c177a474d59b2b/b58d6980429c56560d9241765bdf9c2b.png",
-        "extensions": {
-            "originAssetId": "eip155:1/erc20:0x75231F58b43240C9718Dd58B4967c5114342a86c",
-            "supportedRoutes": [
-                "agglayer"
-            ],
-            "originTokenAddress": "0x75231F58b43240C9718Dd58B4967c5114342a86c",
-            "originTokenNetwork": 0
         }
     },
     {

--- a/src/tokens/defaultTokens.json
+++ b/src/tokens/defaultTokens.json
@@ -87,22 +87,6 @@
                 "symbol": "USDC"
             },
             {
-                "wrappedTokenAddress": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
-                "wrappedNetworkId": 1,
-                "tags": ["lxly", "erc20", "legacy"],
-                "name": "Legacy Bridge USD Coin",
-                "symbol": "USDC"
-            },
-            {
-                "wrappedTokenAddress": "0x37eAA0eF3549a5Bb7D431be78a3D99BD360d19e5",
-                "wrappedNetworkId": 1,
-                "tags": ["zkevmMessageBridge", "erc20"],
-                "originChainBridgeAdapter": "0x70E70e58ed7B1Cec0D8ef7464072ED8A52d755eB",
-                "wrappedChainBridgeAdapter": "0xBDa0B27f93B2FD3f076725b89cf02e48609bC189",
-                "name": "USD Coin",
-                "symbol": "USDC.e"
-            },
-            {
                 "wrappedTokenAddress": "0xfd415d011ffaa8e6f17fa753cdb080d1de266784",
                 "tags": ["agglayer", "erc20"]
             },
@@ -273,18 +257,6 @@
                 "tags": ["lxly", "erc20"]
             },
             {
-                "wrappedTokenAddress": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
-                "wrappedNetworkId": 1,
-                "tags": ["lxly", "erc20", "legacy"]
-            },
-            {
-                "wrappedTokenAddress": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5",
-                "wrappedNetworkId": 1,
-                "tags": ["zkevmMessageBridge", "erc20"],
-                "originChainBridgeAdapter": "0x4A27aC91c5cD3768F140ECabDe3FC2B2d92eDb98",
-                "wrappedChainBridgeAdapter": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5"
-            },
-            {
                 "wrappedTokenAddress": "0x2ff27ca276ff52a4e7c40ff87983c45a4a049e5e",
                 "tags": ["agglayer", "erc20"]
             }
@@ -419,18 +391,6 @@
                 "wrappedTokenAddress": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
                 "wrappedNetworkId": -1,
                 "tags": ["pos", "erc20"]
-            },
-            {
-                "wrappedTokenAddress": "0xbf6de60ccd9d22a5820a658fbe9fc87975ea204f",
-                "wrappedNetworkId": 1,
-                "tags": ["zkevmMessageBridge", "erc20"],
-                "originChainBridgeAdapter": "0xf0CDE1E7F0FAD79771cd526b1Eb0A12F69582C01",
-                "wrappedChainBridgeAdapter": "0xDB5D9c10FD2a92692DB51853e06058EE0436d69B"
-            },
-            {
-                "wrappedTokenAddress": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
-                "tags": ["lxly", "erc20", "legacy"],
-                "wrappedNetworkId": 1
             },
             {
                 "wrappedTokenAddress": "0x7fb4d0f51544f24f385a421db6e7d4fc71ad8e5c",

--- a/src/tokens/defaultTokensStaging.json
+++ b/src/tokens/defaultTokensStaging.json
@@ -120,29 +120,6 @@
                 "symbol": "USDC"
             },
             {
-                "wrappedTokenAddress": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy"
-                ],
-                "name": "Legacy Bridge USD Coin",
-                "symbol": "USDC"
-            },
-            {
-                "wrappedTokenAddress": "0x37eAA0eF3549a5Bb7D431be78a3D99BD360d19e5",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x70E70e58ed7B1Cec0D8ef7464072ED8A52d755eB",
-                "wrappedChainBridgeAdapter": "0xBDa0B27f93B2FD3f076725b89cf02e48609bC189",
-                "name": "USD Coin",
-                "symbol": "USDC.e"
-            },
-            {
                 "wrappedTokenAddress": "0xfd415d011ffaa8e6f17fa753cdb080d1de266784",
                 "tags": [
                     "agglayer",
@@ -407,25 +384,6 @@
                 ]
             },
             {
-                "wrappedTokenAddress": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy"
-                ]
-            },
-            {
-                "wrappedTokenAddress": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x4A27aC91c5cD3768F140ECabDe3FC2B2d92eDb98",
-                "wrappedChainBridgeAdapter": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5"
-            },
-            {
                 "wrappedTokenAddress": "0x2ff27ca276ff52a4e7c40ff87983c45a4a049e5e",
                 "tags": [
                     "agglayer",
@@ -619,25 +577,6 @@
                     "pos",
                     "erc20"
                 ]
-            },
-            {
-                "wrappedTokenAddress": "0xbf6de60ccd9d22a5820a658fbe9fc87975ea204f",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0xf0CDE1E7F0FAD79771cd526b1Eb0A12F69582C01",
-                "wrappedChainBridgeAdapter": "0xDB5D9c10FD2a92692DB51853e06058EE0436d69B"
-            },
-            {
-                "wrappedTokenAddress": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy"
-                ],
-                "wrappedNetworkId": 1
             },
             {
                 "wrappedTokenAddress": "0x7fb4d0f51544f24f385a421db6e7d4fc71ad8e5c",

--- a/src/tokens/defaultTokensTestnet.json
+++ b/src/tokens/defaultTokensTestnet.json
@@ -135,29 +135,6 @@
     },
     {
         "chainId": 11155111,
-        "name": "DevStudio",
-        "symbol": "DST",
-        "decimals": 18,
-        "originTokenAddress": "0x0FDF2329163cA2144704eA251e88B3c59793e266",
-        "originNetworkId": 0,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x6295453Cc3dC3DDAE9592C1390507Ff509f5023C",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x6DE95796C049Fbe47578211183cDC0223f9692Cb",
-                "wrappedChainBridgeAdapter": "0xa2A2b7e365612795E5381214d1c321f245a34E31"
-            }
-        ]
-    },
-    {
-        "chainId": 11155111,
         "name": "Dummy ERC20",
         "symbol": "DERC20",
         "decimals": 18,

--- a/src/tokens/mappedTokens.json
+++ b/src/tokens/mappedTokens.json
@@ -184,29 +184,6 @@
                 "symbol": "USDC"
             },
             {
-                "wrappedTokenAddress": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy"
-                ],
-                "name": "Legacy Bridge USD Coin",
-                "symbol": "USDC"
-            },
-            {
-                "wrappedTokenAddress": "0x37eAA0eF3549a5Bb7D431be78a3D99BD360d19e5",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x70E70e58ed7B1Cec0D8ef7464072ED8A52d755eB",
-                "wrappedChainBridgeAdapter": "0xBDa0B27f93B2FD3f076725b89cf02e48609bC189",
-                "name": "USD Coin",
-                "symbol": "USDC.e"
-            },
-            {
                 "wrappedTokenAddress": "0xfd415d011ffaa8e6f17fa753cdb080d1de266784",
                 "tags": [
                     "agglayer",
@@ -346,16 +323,6 @@
                     "erc20",
                     "legacy"
                 ]
-            },
-            {
-                "wrappedTokenAddress": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x4A27aC91c5cD3768F140ECabDe3FC2B2d92eDb98",
-                "wrappedChainBridgeAdapter": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5"
             },
             {
                 "wrappedTokenAddress": "0x6499d97a606074cb8287dd1570fadba387133e40",
@@ -39629,26 +39596,6 @@
         ],
         "wrappedTokens": [
             {
-                "wrappedTokenAddress": "0xbf6de60ccd9d22a5820a658fbe9fc87975ea204f",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0xf0CDE1E7F0FAD79771cd526b1Eb0A12F69582C01",
-                "wrappedChainBridgeAdapter": "0xDB5D9c10FD2a92692DB51853e06058EE0436d69B"
-            },
-            {
-                "wrappedTokenAddress": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy",
-                    "noDeposit"
-                ],
-                "wrappedNetworkId": 1
-            },
-            {
                 "wrappedTokenAddress": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
                 "wrappedNetworkId": -1,
                 "tags": [
@@ -51956,26 +51903,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "CHERRY_NATIVE_1",
-        "symbol": "CN1",
-        "decimals": 18,
-        "originTokenAddress": "0x47c75a082a748264deea783b587a9bcaa26b3d24",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x47c75a082a748264deea783b587a9bcaa26b3d24",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "MAGA",
         "symbol": "TRUMP",
@@ -51988,146 +51915,6 @@
         "wrappedTokens": [
             {
                 "wrappedTokenAddress": "0x88152f9b973b86c0e31d16f7c4d2896572712131",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
-        "decimals": 18,
-        "originTokenAddress": "0xf4717d8b9b91a0944a2160f4645d63ebb4ec9577",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xf4717d8b9b91a0944a2160f4645d63ebb4ec9577",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "AKADAMA",
-        "symbol": "AKD",
-        "decimals": 18,
-        "originTokenAddress": "0x9ec972dd801305bebbf72dadb68a78ec72bd80b3",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x9ec972dd801305bebbf72dadb68a78ec72bd80b3",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Leet",
-        "symbol": "LEET",
-        "decimals": 18,
-        "originTokenAddress": "0xea0b7a3256829190ea5f587509dee953d213461c",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xea0b7a3256829190ea5f587509dee953d213461c",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "PancakeSwap Token",
-        "symbol": "Cake",
-        "decimals": 18,
-        "originTokenAddress": "0x0d1e753a25ebda689453309112904807625befbe",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x0d1e753a25ebda689453309112904807625befbe",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "agEUR",
-        "symbol": "agEUR",
-        "decimals": 18,
-        "originTokenAddress": "0xa61beb4a3d02decb01039e378237032b351125b4",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xa61beb4a3d02decb01039e378237032b351125b4",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
-        "decimals": 18,
-        "originTokenAddress": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Frax",
-        "symbol": "FRAX",
-        "decimals": 18,
-        "originTokenAddress": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d",
                 "tags": [
                     "lxly",
                     "erc20"
@@ -52482,26 +52269,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "Dyson Sphere",
-        "symbol": "DYSN",
-        "decimals": 18,
-        "originTokenAddress": "0x9cbd81b43ba263ca894178366cfb89a246d1159c",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x00CaAFC7d2C82C4A05504e116327bD398E19985c",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "KuCoin Token",
         "symbol": "KCS",
@@ -52676,26 +52443,6 @@
         "wrappedTokens": [
             {
                 "wrappedTokenAddress": "0x91eba9dd8dfde0e2681d48122d6c7a122d0eeb0e",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Frax Ether",
-        "symbol": "frxETH",
-        "decimals": 18,
-        "originTokenAddress": "0xcf7ecee185f19e2e970a301ee37f93536ed66179",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xcf7ecee185f19e2e970a301ee37f93536ed66179",
                 "tags": [
                     "lxly",
                     "erc20"
@@ -58288,26 +58035,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "Ankr Staked ETH",
-        "symbol": "ankrETH",
-        "decimals": 18,
-        "originTokenAddress": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x9ff5f723452a272cec81cb4591e071297b05589e",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "KOSHER CERTIFIED | VERIFIED | VERITY",
         "symbol": "KOSHER",
@@ -58903,26 +58630,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "Aura",
-        "symbol": "AURA",
-        "decimals": 18,
-        "originTokenAddress": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x741971af1fb2951bcf25ac0a61411687be5869de",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "Frankencoin Pool Share",
         "symbol": "FPS",
@@ -59332,40 +59039,6 @@
                     "lxly",
                     "erc20"
                 ]
-            }
-        ]
-    },
-    {
-        "chainId": 1,
-        "name": "Gyro Dollar",
-        "symbol": "GYD",
-        "decimals": 18,
-        "originTokenAddress": "0xe07F9D810a48ab5c3c914BA3cA53AF14E4491e8A",
-        "originNetworkId": 0,
-        "tags": [
-            "erc20"
-        ],
-        "logoURI": "https://app.gyro.finance/_next/static/media/gyd.aab5a49d.svg",
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0xF3387a880998C9B9169bc9973E8826Fc9035c171",
-                "wrappedChainBridgeAdapter": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8"
-            },
-            {
-                "wrappedTokenAddress": "0x9496C473A7b1809dE32198aE1C23a7Ba844D9f6d",
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy",
-                    "noDeposit"
-                ],
-                "wrappedNetworkId": 1
             }
         ]
     },

--- a/src/tokens/mappedTokensStaging.json
+++ b/src/tokens/mappedTokensStaging.json
@@ -184,29 +184,6 @@
                 "symbol": "USDC"
             },
             {
-                "wrappedTokenAddress": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy"
-                ],
-                "name": "Legacy Bridge USD Coin",
-                "symbol": "USDC"
-            },
-            {
-                "wrappedTokenAddress": "0x37eAA0eF3549a5Bb7D431be78a3D99BD360d19e5",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x70E70e58ed7B1Cec0D8ef7464072ED8A52d755eB",
-                "wrappedChainBridgeAdapter": "0xBDa0B27f93B2FD3f076725b89cf02e48609bC189",
-                "name": "USD Coin",
-                "symbol": "USDC.e"
-            },
-            {
                 "wrappedTokenAddress": "0xfd415d011ffaa8e6f17fa753cdb080d1de266784",
                 "tags": [
                     "agglayer",
@@ -346,16 +323,6 @@
                     "erc20",
                     "legacy"
                 ]
-            },
-            {
-                "wrappedTokenAddress": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x4A27aC91c5cD3768F140ECabDe3FC2B2d92eDb98",
-                "wrappedChainBridgeAdapter": "0x744C5860ba161b5316F7E80D9Ec415e2727e5bD5"
             },
             {
                 "wrappedTokenAddress": "0x6499d97a606074cb8287dd1570fadba387133e40",
@@ -39384,26 +39351,6 @@
         ],
         "wrappedTokens": [
             {
-                "wrappedTokenAddress": "0xbf6de60ccd9d22a5820a658fbe9fc87975ea204f",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0xf0CDE1E7F0FAD79771cd526b1Eb0A12F69582C01",
-                "wrappedChainBridgeAdapter": "0xDB5D9c10FD2a92692DB51853e06058EE0436d69B"
-            },
-            {
-                "wrappedTokenAddress": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy",
-                    "noDeposit"
-                ],
-                "wrappedNetworkId": 1
-            },
-            {
                 "wrappedTokenAddress": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
                 "wrappedNetworkId": -1,
                 "tags": [
@@ -51662,26 +51609,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "CHERRY_NATIVE_1",
-        "symbol": "CN1",
-        "decimals": 18,
-        "originTokenAddress": "0x47c75a082a748264deea783b587a9bcaa26b3d24",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x47c75a082a748264deea783b587a9bcaa26b3d24",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "MAGA",
         "symbol": "TRUMP",
@@ -51694,146 +51621,6 @@
         "wrappedTokens": [
             {
                 "wrappedTokenAddress": "0x88152f9b973b86c0e31d16f7c4d2896572712131",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
-        "decimals": 18,
-        "originTokenAddress": "0xf4717d8b9b91a0944a2160f4645d63ebb4ec9577",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xf4717d8b9b91a0944a2160f4645d63ebb4ec9577",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "AKADAMA",
-        "symbol": "AKD",
-        "decimals": 18,
-        "originTokenAddress": "0x9ec972dd801305bebbf72dadb68a78ec72bd80b3",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x9ec972dd801305bebbf72dadb68a78ec72bd80b3",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Leet",
-        "symbol": "LEET",
-        "decimals": 18,
-        "originTokenAddress": "0xea0b7a3256829190ea5f587509dee953d213461c",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xea0b7a3256829190ea5f587509dee953d213461c",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "PancakeSwap Token",
-        "symbol": "Cake",
-        "decimals": 18,
-        "originTokenAddress": "0x0d1e753a25ebda689453309112904807625befbe",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x0d1e753a25ebda689453309112904807625befbe",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "agEUR",
-        "symbol": "agEUR",
-        "decimals": 18,
-        "originTokenAddress": "0xa61beb4a3d02decb01039e378237032b351125b4",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xa61beb4a3d02decb01039e378237032b351125b4",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
-        "decimals": 18,
-        "originTokenAddress": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Frax",
-        "symbol": "FRAX",
-        "decimals": 18,
-        "originTokenAddress": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xff8544fed5379d9ffa8d47a74ce6b91e632ac44d",
                 "tags": [
                     "lxly",
                     "erc20"
@@ -52188,26 +51975,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "Dyson Sphere",
-        "symbol": "DYSN",
-        "decimals": 18,
-        "originTokenAddress": "0x9cbd81b43ba263ca894178366cfb89a246d1159c",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x9cbd81b43ba263ca894178366cfb89a246d1159c",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "KuCoin Token",
         "symbol": "KCS",
@@ -52382,26 +52149,6 @@
         "wrappedTokens": [
             {
                 "wrappedTokenAddress": "0x91eba9dd8dfde0e2681d48122d6c7a122d0eeb0e",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 1101,
-        "name": "Frax Ether",
-        "symbol": "frxETH",
-        "decimals": 18,
-        "originTokenAddress": "0xcf7ecee185f19e2e970a301ee37f93536ed66179",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xcf7ecee185f19e2e970a301ee37f93536ed66179",
                 "tags": [
                     "lxly",
                     "erc20"
@@ -57994,26 +57741,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "Ankr Staked ETH",
-        "symbol": "ankrETH",
-        "decimals": 18,
-        "originTokenAddress": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x9ff5f723452a272cec81cb4591e071297b05589e",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "KOSHER CERTIFIED | VERIFIED | VERITY",
         "symbol": "KOSHER",
@@ -58609,26 +58336,6 @@
         ]
     },
     {
-        "chainId": 1101,
-        "name": "Aura",
-        "symbol": "AURA",
-        "decimals": 18,
-        "originTokenAddress": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x741971af1fb2951bcf25ac0a61411687be5869de",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 1,
         "name": "Frankencoin Pool Share",
         "symbol": "FPS",
@@ -59038,40 +58745,6 @@
                     "lxly",
                     "erc20"
                 ]
-            }
-        ]
-    },
-    {
-        "chainId": 1,
-        "name": "Gyro Dollar",
-        "symbol": "GYD",
-        "decimals": 18,
-        "originTokenAddress": "0xe07F9D810a48ab5c3c914BA3cA53AF14E4491e8A",
-        "originNetworkId": 0,
-        "tags": [
-            "erc20"
-        ],
-        "logoURI": "https://app.gyro.finance/_next/static/media/gyd.aab5a49d.svg",
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0xF3387a880998C9B9169bc9973E8826Fc9035c171",
-                "wrappedChainBridgeAdapter": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8"
-            },
-            {
-                "wrappedTokenAddress": "0x9496C473A7b1809dE32198aE1C23a7Ba844D9f6d",
-                "tags": [
-                    "lxly",
-                    "erc20",
-                    "legacy",
-                    "noDeposit"
-                ],
-                "wrappedNetworkId": 1
             }
         ]
     },

--- a/src/tokens/mappedTokensTestnet.json
+++ b/src/tokens/mappedTokensTestnet.json
@@ -1,25 +1,5 @@
 [
     {
-        "chainId": 2442,
-        "name": "I am mine",
-        "symbol": "MINE",
-        "decimals": 18,
-        "originTokenAddress": "0xc949f6e273de0fc7e057c39ad3c83859732627c3",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xadaaa72158ee2b174b9b7b1a06fb0d655d582a64",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "Dummy ERC20",
         "symbol": "DERC20",
@@ -200,26 +180,6 @@
         ]
     },
     {
-        "chainId": 2442,
-        "name": "PayToken",
-        "symbol": "PTK",
-        "decimals": 18,
-        "originTokenAddress": "0xc3e9a9ef91982aaff10274be170b28d6a1d952d3",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x4973a09fea4bef8f089ab849d520af8c99813d72",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "USDC",
         "symbol": "USDC",
@@ -360,26 +320,6 @@
         ]
     },
     {
-        "chainId": 2442,
-        "name": "PayToken",
-        "symbol": "PTK",
-        "decimals": 18,
-        "originTokenAddress": "0x6780f3acb82b5fd847a4d420cfac7d901ee84076",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x83147790e2b569604dc9adf136f9b177ce32eb1d",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "Bikera",
         "symbol": "MERA",
@@ -392,26 +332,6 @@
         "wrappedTokens": [
             {
                 "wrappedTokenAddress": "0x9c78bb41121726ec62d657dfb9124051e9c6ca66",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 2442,
-        "name": "NEEV NETWORK TESTNET",
-        "symbol": "tNEEV",
-        "decimals": 18,
-        "originTokenAddress": "0x9a23b162ebe81cdf7095724af601b102469ac07d",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x84d9ec2fe586d650375cc37bb180750c49d4d17a",
                 "tags": [
                     "lxly",
                     "erc20"
@@ -484,46 +404,6 @@
                 "wrappedNetworkId": -1,
                 "tags": [
                     "pos",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 2442,
-        "name": "Cardona Points",
-        "symbol": "CRDNA",
-        "decimals": 18,
-        "originTokenAddress": "0x94ab230b92a3f2899e81d46d4e874c6f006c88aa",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xa1748f5e8939776a9cf74fb8e78b22e00210d31b",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 2442,
-        "name": "hajmola",
-        "symbol": "HJ",
-        "decimals": 18,
-        "originTokenAddress": "0xba73866cb1d2407bb6c62cb612e3b4ddf035ae05",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x926b8d456b0b840a9eda949ad5df5e039a596c0c",
-                "tags": [
-                    "lxly",
                     "erc20"
                 ]
             }
@@ -976,26 +856,6 @@
         ]
     },
     {
-        "chainId": 2442,
-        "name": "Mitosis Wrapped EtherFi Ether",
-        "symbol": "miweETH",
-        "decimals": 18,
-        "originTokenAddress": "0x4116f5aa85fdfc063a19bedd740c08c1b3ad15c5",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x7c4ede3e553b7ef836fbc85ca90d9acec408cc17",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "STOS Token",
         "symbol": "STOS",
@@ -1174,26 +1034,6 @@
         "wrappedTokens": [
             {
                 "wrappedTokenAddress": "0x1e9e294e9003fe3471a6d7be6b302fcba6621271",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 2442,
-        "name": "TEST1",
-        "symbol": "TT",
-        "decimals": 18,
-        "originTokenAddress": "0xd7704eccb6d9355e7723fa92d5704c5c70031c8d",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x262fec096869bf57bddaffb2fe6b4f37e6383055",
                 "tags": [
                     "lxly",
                     "erc20"
@@ -2557,46 +2397,6 @@
         ]
     },
     {
-        "chainId": 2442,
-        "name": "A COIN",
-        "symbol": "ACO",
-        "decimals": 18,
-        "originTokenAddress": "0xaf06af0885aad7791dba0da07d91db7e1024d46b",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x43ded846016e018986e5f4ed84f0fb10f06615f7",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "chainId": 2442,
-        "name": "A COIN",
-        "symbol": "ACO",
-        "decimals": 18,
-        "originTokenAddress": "0x40867603ba72cefe945233d923b4b04e6364cacd",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x709ef363c2554ceca37472bf39451ed2eb0eb5af",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "USDC",
         "symbol": "USDC",
@@ -3067,26 +2867,6 @@
         ]
     },
     {
-        "chainId": 2442,
-        "name": "A COIN",
-        "symbol": "ACO",
-        "decimals": 18,
-        "originTokenAddress": "0x7f9f26bcc8fc483804a07df3e852266cc321933e",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xfc49e626ca1cf2f8be17a52b4f015cacb3a56460",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "LUSD",
         "symbol": "LUSD",
@@ -3169,26 +2949,6 @@
         ]
     },
     {
-        "chainId": 2442,
-        "name": "Aggregation Layer Token",
-        "symbol": "AGG",
-        "decimals": 18,
-        "originTokenAddress": "0x88342beb50513c9994696c1dadeedad5e8b763df",
-        "originNetworkId": 1,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xa239f92e2d4356b26118a0cfb1d515c5c5ac5f16",
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
         "chainId": 11155111,
         "name": "Aggregation Layer Token",
         "symbol": "AGG",
@@ -3261,46 +3021,6 @@
                 "wrappedNetworkId": -1,
                 "tags": [
                     "plasma",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "name": "UnirisToken",
-        "symbol": "UCO",
-        "decimals": 18,
-        "originTokenAddress": "0x1ac1544bba39d35951a10375465d18ae6a75a86a",
-        "originNetworkId": 0,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0xcdf374bf62756cf8f3da0f088cbb68678881f4f7",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "lxly",
-                    "erc20"
-                ]
-            }
-        ]
-    },
-    {
-        "name": "Wrapped Bitcoin",
-        "symbol": "WBTC",
-        "decimals": 8,
-        "originTokenAddress": "0xad9d14ca82d9bf97fff745ffc7d48172a1c0969e",
-        "originNetworkId": 0,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x181fed81cf25388eb4e4e9f81c7ddf82b9b07f79",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "lxly",
                     "erc20"
                 ]
             }
@@ -3576,29 +3296,6 @@
                     "fx",
                     "erc721"
                 ]
-            }
-        ]
-    },
-    {
-        "chainId": 11155111,
-        "name": "DevStudio",
-        "symbol": "DST",
-        "decimals": 18,
-        "originTokenAddress": "0x0FDF2329163cA2144704eA251e88B3c59793e266",
-        "originNetworkId": 0,
-        "tags": [
-            "erc20"
-        ],
-        "wrappedTokens": [
-            {
-                "wrappedTokenAddress": "0x6295453Cc3dC3DDAE9592C1390507Ff509f5023C",
-                "wrappedNetworkId": 1,
-                "tags": [
-                    "zkevmMessageBridge",
-                    "erc20"
-                ],
-                "originChainBridgeAdapter": "0x6DE95796C049Fbe47578211183cDC0223f9692Cb",
-                "wrappedChainBridgeAdapter": "0xa2A2b7e365612795E5381214d1c321f245a34E31"
             }
         ]
     },


### PR DESCRIPTION
Polygon zkEVM sequencers are being stopped, so zkEVM is removed as a chain and token option across the published tokenlists. Two commits: the agglayer list (removes zkEVM from agglayer-ui's chain/token registries) and the mapped/default lists (dead data — portal already dropped zkEVM at its chain layer and skips these entries at parse time). Deletions only; generic `lxly` CDK legs without a `wrappedNetworkId` are intentionally kept.

Part of https://github.com/agglayer/agglayer-ui/issues/191

🤖 Generated with [Claude Code](https://claude.com/claude-code)